### PR TITLE
styleCop dep set to developmentDependency=true

### DIFF
--- a/Klarna.Rest/Klarna.Rest/packages.config
+++ b/Klarna.Rest/Klarna.Rest/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net4" userInstalled="true" />
-  <package id="StyleCop" version="4.7.49.0" targetFramework="net4" userInstalled="true" />
+  <package id="StyleCop" version="4.7.49.0" targetFramework="net4" developmentDependency="true" userInstalled="true" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net4" developmentDependency="true" userInstalled="true" />
 </packages>


### PR DESCRIPTION
Sets stylecop as development dependency, so I as a client do not get it in my projects.
