### PR TITLE
Set DefaultValueHandling to Include

### DIFF
--- a/Klarna.Rest/Klarna.Rest.Core/Serialization/JsonSerializer.cs
+++ b/Klarna.Rest/Klarna.Rest.Core/Serialization/JsonSerializer.cs
@@ -17,7 +17,7 @@ namespace Klarna.Rest.Core.Serialization
         protected JsonSerializerSettings SerializerSettings = new JsonSerializerSettings
         {
             NullValueHandling = NullValueHandling.Ignore,
-            DefaultValueHandling = DefaultValueHandling.Ignore,
+            DefaultValueHandling = DefaultValueHandling.Include,
             Converters = new List<JsonConverter>()
             {
                 new IsoDateTimeConverter


### PR DESCRIPTION
When the DefaultValueHandling is set to `Ignore` the serializer will ignore properties of value `0`. This is causing null exceptions when the `OrderLine` amounts are zero.

Fixes #21