### PR TITLE
AllowedCustomerTypes should be a collection

### DIFF
--- a/Klarna.Rest/Klarna.Rest.Core/Model/CheckoutOptions.cs
+++ b/Klarna.Rest/Klarna.Rest.Core/Model/CheckoutOptions.cs
@@ -85,7 +85,7 @@ namespace Klarna.Rest.Core.Model
         /// A list of allowed customer types. Supported types: person & organization
         /// </summary>
         [JsonProperty(PropertyName = "allowed_customer_types")]
-        public string AllowedCustomerTypes { get; set; }
+        public ICollection<string> AllowedCustomerTypes { get; set; }
         /// <summary>
         /// If true, the Order Detail subtotals view is expanded. Default: false
         /// </summary>


### PR DESCRIPTION
`AllowedCustomerTypes` is currently a `string` but should really be a collection i.e `ICollection<string>`. Right now this is causing the deserializing to fail.