### PR TITLE
Fix HPP distribution method. The method did not send a body payout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [Unreleased] (BugFix Release)
 
 ### Changed
 
 ### Added
 
 ### Fixed
+
+- HostedPaymentPage distribute session method did not send a body payout. Resolves [#72](https://github.com/klarna/kco_rest_dotnet/issues/72);
 
 
 ## [3.1.6.1] - 2019-10-16 (Enhancements)

--- a/Klarna.Rest/Klarna.Rest.Core/Store/HostedPaymentPageStore.cs
+++ b/Klarna.Rest/Klarna.Rest.Core/Store/HostedPaymentPageStore.cs
@@ -43,7 +43,7 @@ namespace Klarna.Rest.Core.Store
         public Task DistributeLinkToSession(string sessionId, HostedPaymentPageDistributeLink distribution)
         {
             var url = ApiUrlHelper.GetApiUrlForController(ApiSession.ApiUrl, ApiControllerUri, $"{sessionId}/distribution");
-            return Post(url);
+            return Post(url, distribution);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #72 