### PR TITLE
Fix settlement transaction model namespace

### DIFF
--- a/Klarna.Rest/Klarna.Rest.Core/Model/SettlementsGetTransactionsResponse.cs
+++ b/Klarna.Rest/Klarna.Rest.Core/Model/SettlementsGetTransactionsResponse.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace Klarna.Rest.Core.Model.Settlements
+namespace Klarna.Rest.Core.Model
 {
     /// <summary>
     /// Get transaction response object
@@ -15,12 +15,12 @@ namespace Klarna.Rest.Core.Model.Settlements
         /// </summary>
         /// <remarks>Required</remarks>
         [JsonProperty(PropertyName = "transactions")]
-        public ICollection<Transaction> Transactions { get; set; }
+        public ICollection<Settlements.Transaction> Transactions { get; set; }
         /// <summary>
         /// Pagination information
         /// </summary>
         /// <remarks>Required</remarks>
         [JsonProperty(PropertyName = "pagination")]
-        public Pagination Pagination { get; set; }
+        public Settlements.Pagination Pagination { get; set; }
     }
 }

--- a/Klarna.Rest/Klarna.Rest.Core/Model/SettlementsGetTransactionsResponse.cs
+++ b/Klarna.Rest/Klarna.Rest.Core/Model/SettlementsGetTransactionsResponse.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace Klarna.Rest.Core.Model
+namespace Klarna.Rest.Core.Model.Settlements
 {
     /// <summary>
     /// Get transaction response object


### PR DESCRIPTION
Hey,

The function `Settlement.GetTransactions(...)` returns an object of type `SettlementsGetTransactionsResponse` that's suppose to have the auto generated models for Transaction and Pagination, but as the namespace is wrong it returns the Transactions of the old format, missing properties like `DetailedType`.

In this PR I've only added the correct namespace to the type inside of `SettlementsGetTransactionsResponse`, so it should work without any additional changes.

Cheers!