### PR TITLE
Release v3.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.10] (Enhancements Release/Auto-generated models) - 2019-12-10
 
+⚠️ This version is marked as **broken/deprecated**. Consider to use v3.1.12 instead.
+
 This release contains fully updated API models. All the models were split by appropriate API entitities
 and all the models are auto-generated now. This change simplifies keeping up-to-date changes in the API 
 request/response.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Added
+
+### Fixed
+
+
+
+## [3.1.12] - 2020-02-14
+
+### Changed
+
 - Rolled back previous model changes. Remove obsolescence notices.
 
 ### Added
 
-### Fixed
+- HTTP Transport: Oceania Base URLs (playground and production)
 
 
 ## [3.1.10] (Enhancements Release/Auto-generated models) - 2019-12-10
@@ -258,7 +268,8 @@ and fixes [#77](https://github.com/klarna/kco_rest_dotnet/issues/77)
 
 - **NEW MINT-1912** Support checkout v3 and ordermanagement v1 APIs - *Joakim.L*
 
-[Unreleased]: https://github.com/klarna/kco_rest_dotnet/compare/v3.1.10...HEAD
+[Unreleased]: https://github.com/klarna/kco_rest_dotnet/compare/v3.1.12...HEAD
+[3.1.12]: https://github.com/klarna/kco_rest_dotnet/compare/v3.1.10...v3.1.12
 [3.1.10]: https://github.com/klarna/kco_rest_dotnet/compare/v3.1.9...v3.1.10
 [3.1.9]: https://github.com/klarna/kco_rest_dotnet/compare/v3.1.8...v3.1.9
 [3.1.8]: https://github.com/klarna/kco_rest_dotnet/compare/v3.1.7...v3.1.8

--- a/Klarna.Rest/Klarna.Rest.Core/Common/Constants.cs
+++ b/Klarna.Rest/Klarna.Rest.Core/Common/Constants.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// The current version of .NET SDK library for Klarna Services
         /// </summary>
-        public const string Version = "3.1.11";
+        public const string Version = "3.1.12";
 
         /// <summary>
         /// The API for the European live environment

--- a/Klarna.Rest/Klarna.Rest.Core/Common/Constants.cs
+++ b/Klarna.Rest/Klarna.Rest.Core/Common/Constants.cs
@@ -21,6 +21,11 @@
         public const string ProdUrlNorthAmerica = "https://api-na.klarna.com/";
 
         /// <summary>
+        /// The API for the Oceania live environment
+        /// </summary>
+        public const string ProdUrlOceania = "https://api-oc.klarna.com/";
+
+        /// <summary>
         /// The API for the European testing environment
         /// </summary>
         public const string TestUrlEurope = "https://api.playground.klarna.com/";
@@ -29,5 +34,10 @@
         /// The API for the U.S. testing environment
         /// </summary>
         public const string TestUrlNorthAmerica = "https://api-na.playground.klarna.com/";
+
+        /// <summary>
+        /// The API for the Oceania testing environment
+        /// </summary>
+        public const string TestUrlOceania = "https://api-oc.playground.klarna.com/";
     }
 }

--- a/Klarna.Rest/Klarna.Rest.Core/Klarna.Rest.Core.csproj
+++ b/Klarna.Rest/Klarna.Rest.Core/Klarna.Rest.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>3.1.11</Version>
+    <Version>3.1.12</Version>
     <AssemblyName>Klarna.Rest.Core</AssemblyName>
     <AssemblyTitle>Klarna Checkout REST .NET SDK</AssemblyTitle>
     <OutputType>Library</OutputType>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Register here to be able to test your SDK integration before go live:
 
 ## Installation and Usage
 
+### Important Notices
+
+⚠️ v3.1.10 is marked as **broken/deprecated**. Consider to use v3.1.12 instead.
+
 ### Examples
 
 Example files can be found in the [examples](Klarna.Rest/Klarna.Rest.Core.Examples) project.    


### PR DESCRIPTION
### Changed

- Rolled back previous model changes. Remove obsolescence notices.

### Added

- HTTP Transport: Oceania Base URLs (playground and production)